### PR TITLE
Change output node field from Nuke to Houdini alias

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -6,7 +6,7 @@ configuration:
 
   output_render_template:
     type: template
-    fields: context, version, SEQ, [aov_name], [name], [width], [height], *
+    fields: context, version, SEQ, [node], [aov_name], [name], [width], [height], *
     description: A template which describes the output of the render.
 
   render_metadata:

--- a/python/tk_houdini_karma/handler.py
+++ b/python/tk_houdini_karma/handler.py
@@ -246,7 +246,7 @@ class karma_node_handler(object):
         # Set fields
         fields = work_template.get_fields(current_filepath)
         fields["SEQ"] = "FORMAT: $F"
-        fields["output"] = node.parm("name").eval()
+        fields["node"] = node.parm("name").eval()
         fields["aov_name"] = aov_name
         fields["width"] = node.parm("resolutionx").eval()
         fields["height"] = node.parm("resolutiony").eval()


### PR DESCRIPTION
Fixes #12, breaking changes when using `write.output` in Houdini templates.